### PR TITLE
added browser path to be set using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
         "CHROME_DEBUGGING_HOST": "localhost",
         "CHROME_PERSISTENT_SESSION": "false",
         "BROWSER_HEADLESS": "false",
+        "BROWSER_CHROME_INSTANCE_PATH" : "",
         "BROWSER_DISABLE_SECURITY": "false",
         "BROWSER_WINDOW_WIDTH": "1280",
         "BROWSER_WINDOW_HEIGHT": "720",

--- a/src/mcp_server_browser_use/server.py
+++ b/src/mcp_server_browser_use/server.py
@@ -84,6 +84,7 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
         # Get browser configuration
         headless = get_env_bool("BROWSER_HEADLESS", True)
         disable_security = get_env_bool("BROWSER_DISABLE_SECURITY", False)
+        chrome_instance_path = os.getenv("BROWSER_CHROME_INSTANCE_PATH", None)
         window_w = int(os.getenv("BROWSER_WINDOW_WIDTH", "1280"))
         window_h = int(os.getenv("BROWSER_WINDOW_HEIGHT", "720"))
 
@@ -105,6 +106,7 @@ async def run_browser_agent(task: str, add_infos: str = "") -> str:
                 config=BrowserConfig(
                     headless=headless,
                     disable_security=disable_security,
+                    chrome_instance_path=chrome_instance_path,
                     extra_chromium_args=extra_chromium_args,
                 )
             )


### PR DESCRIPTION
I was playing around with mcp-browser-use and wanted to set the path to my existing browser as mentioned in #5

In this issue there was ask for a PR so i thought lets just create that so here it is.