### PR TITLE
Add standard environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
         "MCP_MAX_STEPS": "30",
         "MCP_USE_VISION": "true",
         "MCP_MAX_ACTIONS_PER_STEP": "5",
-        "MCP_TOOL_CALL_IN_CONTENT": "true"
+        "MCP_TOOL_CALL_IN_CONTENT": "true",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONUTF8": "1"
     }
 }
 ```
@@ -98,7 +101,9 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
     "mcp-server-browser-use"
   ],
   "env": {
-    ...
+    "PYTHONIOENCODING": "utf-8",
+    "PYTHONUNBUFFERED": "1",
+    "PYTHONUTF8": "1"
   }
 }
 ```


### PR DESCRIPTION
Add standard environment variables to `README.md`.

* **Environment Variables:**
  - Add `PYTHONIOENCODING` with value `utf-8`
  - Add `PYTHONUNBUFFERED` with value `1`
  - Add `PYTHONUTF8` with value `1`

Fixes UnicodeError in Windows.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Saik0s/mcp-browser-use/pull/10?shareId=5f5a6f3f-ab2b-4bf3-946b-7b881b51d6c4).