### PR TITLE
Add support for chromium_sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ mcp-server-browser-use config set -k agent.max_steps -v 30
 | `browser.headless` | `true` | Run browser without GUI |
 | `browser.cdp_url` | - | Connect to existing Chrome (e.g., http://localhost:9222) |
 | `browser.user_data_dir` | - | Chrome profile directory for persistent logins/cookies |
+| `browser.chromium_sandbox` | `true` | Enable Chromium sandboxing for security |
 | `agent.max_steps` | `20` | Max steps per browser task |
 | `agent.use_vision` | `true` | Enable vision capabilities for the agent |
 | `research.max_searches` | `5` | Max searches per research task |

--- a/src/mcp_server_browser_use/config.py
+++ b/src/mcp_server_browser_use/config.py
@@ -159,6 +159,7 @@ class BrowserSettings(BaseSettings):
     proxy_bypass: str | None = Field(default=None, description="Comma-separated hosts to bypass proxy")
     cdp_url: str | None = Field(default=None, description="CDP URL for external browser (e.g., http://localhost:9222)")
     user_data_dir: str | None = Field(default=None, description="Path to Chrome user data directory for persistent profile")
+    chromium_sandbox: bool = Field(default=True)
 
     @model_validator(mode="after")
     def validate_cdp_url(self) -> "BrowserSettings":

--- a/src/mcp_server_browser_use/server.py
+++ b/src/mcp_server_browser_use/server.py
@@ -113,6 +113,7 @@ def serve() -> FastMCP:
             proxy=proxy,
             cdp_url=settings.browser.cdp_url,
             user_data_dir=settings.browser.user_data_dir,
+            chromium_sandbox=settings.browser.chromium_sandbox,
         )
         if settings.browser.cdp_url:
             logger.info(f"Using external browser via CDP: {settings.browser.cdp_url}")


### PR DESCRIPTION
In some environments, chrome needs to be executed with the  `--no-sandbox` flag. Browser-use supports that through the `chromium_sandbox=True/False` configuration (in BrowserProfile).